### PR TITLE
Add error checking and clean up spacing

### DIFF
--- a/Dockerfile.jessie-arm64
+++ b/Dockerfile.jessie-arm64
@@ -15,7 +15,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get upgrade -y && apt-g
   liblzma-dev \
   pkg-config \
   python \
-  python3 python3-dev:arm64\
+  python3 \
+  python3-dev:arm64 \
   sudo \
   vim-nox
 RUN curl -sL https://releases.linaro.org/components/toolchain/binaries/4.9-2017.01/aarch64-linux-gnu/gcc-linaro-4.9.4-2017.01-x86_64_aarch64-linux-gnu.tar.xz | tar xJ -C /opt && \

--- a/Dockerfile.trusty-arm32
+++ b/Dockerfile.trusty-arm32
@@ -17,7 +17,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get upgrade && apt-get 
   git-core \
   pkg-config \
   python \
-  python3 python3-dev:arm64\
+  python3 \
+  python3-dev:arm64 \
   sudo \
   vim-nox
 RUN (cd /tmp && curl -sLO https://cmake.org/files/v3.8/cmake-3.8.2-Linux-x86_64.sh && chmod u+x cmake*.sh && ./cmake-3.8.2-Linux-x86_64.sh --skip-license --prefix=/usr/local && rm -f cmake* )

--- a/Dockerfile.trusty-arm64
+++ b/Dockerfile.trusty-arm64
@@ -16,7 +16,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get upgrade -y && apt-g
   libpcre3:arm64 \
   pkg-config \
   python \
-  python3 python3-dev:arm64\
+  python3 \
+  python3-dev:arm64 \
   sudo \
   vim-nox
 RUN (cd /tmp && curl -sLO https://cmake.org/files/v3.8/cmake-3.8.2-Linux-x86_64.sh && chmod u+x cmake*.sh && ./cmake-3.8.2-Linux-x86_64.sh --skip-license --prefix=/usr/local && rm -f cmake* )

--- a/Dockerfile.vivid-arm32
+++ b/Dockerfile.vivid-arm32
@@ -17,7 +17,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get upgrade && apt-get 
   git-core \
   pkg-config \
   python \
-  python3 python3-dev:arm64\
+  python3 \
+  python3-dev:arm64 \
   sudo \
   vim-nox
 RUN (cd /tmp && curl -sLO https://cmake.org/files/v3.8/cmake-3.8.2-Linux-x86_64.sh && chmod u+x cmake*.sh && ./cmake-3.8.2-Linux-x86_64.sh --skip-license --prefix=/usr/local && rm -f cmake* )

--- a/Dockerfile.wily-arm64
+++ b/Dockerfile.wily-arm64
@@ -21,7 +21,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get upgrade -y && apt-g
   git-core \
   pkg-config \
   python \
-  python3 python3-dev:arm64\
+  python3 \
+  python3-dev:arm64 \
   mono-mcs \
   openjdk-8-jdk \
   sudo \

--- a/Dockerfile.xenial-arm64
+++ b/Dockerfile.xenial-arm64
@@ -15,7 +15,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get upgrade -y && apt-g
   git-core \
   pkg-config \
   python \
-  python3 python3-dev:arm64\
+  python3 \
+  python3-dev:arm64 \
   sudo \
   vim-nox
 RUN (cd /tmp && curl -sLO https://cmake.org/files/v3.8/cmake-3.8.2-Linux-x86_64.sh && chmod u+x cmake*.sh && ./cmake-3.8.2-Linux-x86_64.sh --skip-license --prefix=/usr/local && rm -f cmake* )

--- a/scripts/build_images.sh
+++ b/scripts/build_images.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -xe
 
 #Generate images for use with external libraries
 

--- a/scripts/docker-user
+++ b/scripts/docker-user
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/bin/bash -e
 
 
 image=${@: -1}

--- a/scripts/docker-user
+++ b/scripts/docker-user
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -xe
 
 
 image=${@: -1}

--- a/scripts/leap-libraries
+++ b/scripts/leap-libraries
@@ -1,4 +1,4 @@
-#!/bin/sh -xe
+#!/bin/sh -e
 
 echo "This script remains for reference for cross-builds of a handful of libraries"
 echo "To build other external libraries, see the leapmotion/external-libraries repo"

--- a/scripts/leap-libraries
+++ b/scripts/leap-libraries
@@ -1,5 +1,7 @@
-#!/bin/sh
+#!/bin/sh -xe
 
+echo "This script remains for reference for cross-builds of a handful of libraries"
+echo "To build other external libraries, see the leapmotion/external-libraries repo"
 if [ "$ARCH" = "arm32" ]; then
   export CROSS_COMPILE=arm-linux-gnueabihf-
   INSTALL_DIR=/opt/local/Libraries-arm32
@@ -97,12 +99,12 @@ boost_build() {
 }
 
 boost_build 1.64.0
-leap_build "autowiring" 1.0.3 "AutowiringTest"
-leap_build "leapserial" 0.4.0 "LeapSerialTest"
+leap_build "autowiring" 1.0.5 "AutowiringTest"
+leap_build "leapserial" 0.5.1 "LeapSerialTest"
 
 if [ $autowiring_CHANGED ] || [ $LeapSerial_CHANGED ]; then
  autowiring_LeapSerial_CHANGED=true
 fi
-leap_build "LeapResource" 0.1.1 "LeapResourceTest" $autowiring_LeapSerial_CHANGED
-leap_build "LeapHTTP" 0.1.1 "LeapHTTPTest" $autowiring_CHANGED
-leap_build "LeapIPC" 0.1.4 "LeapIPCTest" $autowiring_LeapSerial_CHANGED
+leap_build "LeapResource" 0.1.3 "LeapResourceTest" $autowiring_LeapSerial_CHANGED
+leap_build "LeapHTTP" 0.1.3 "LeapHTTPTest" $autowiring_CHANGED
+leap_build "LeapIPC" 0.1.7 "LeapIPCTest" $autowiring_LeapSerial_CHANGED


### PR DESCRIPTION
I merged a couple PRs on Friday that moved things forward but served as a reminder of some stuff to clean up.

This PR mainly adds error-checking `bash -e` to scripts, and tidies up all the `python-dev:arm64` lines to look the same as other packages in the list.