### PR TITLE
Add patchelf for CPack requirements

### DIFF
--- a/Dockerfile.xenial-arm64
+++ b/Dockerfile.xenial-arm64
@@ -13,6 +13,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get upgrade -y && apt-g
   libglu1-mesa-dev:arm64 \
   g++-4.9-aarch64-linux-gnu \
   git-core \
+  patchelf \
   pkg-config \
   python \
   python3 \

--- a/Dockerfile.xenial-arm64-gcc5
+++ b/Dockerfile.xenial-arm64-gcc5
@@ -24,6 +24,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get upgrade -y && apt-g
   mono-mcs \
   ninja-build \
   openjdk-8-jdk \
+  patchelf \
   pkg-config \
   python \
   python3:arm64 \

--- a/Dockerfile.xenial-x86_64
+++ b/Dockerfile.xenial-x86_64
@@ -12,6 +12,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get upgrade -y && apt-g
   libxi-dev \
   g++-4.9 \
   git-core \
+  patchelf \
   pkg-config \
   python \
   sudo \

--- a/Dockerfile.xenial-x86_64-gcc4.8
+++ b/Dockerfile.xenial-x86_64-gcc4.8
@@ -12,6 +12,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get upgrade -y && apt-g
   libxi-dev \
   g++-4.8 \
   git-core \
+  patchelf \
   pkg-config \
   libtool-bin \
   automake \

--- a/Dockerfile.xenial-x86_64-gcc5
+++ b/Dockerfile.xenial-x86_64-gcc5
@@ -17,6 +17,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get upgrade -y && apt-g
   mono-mcs \
   ninja-build \
   openjdk-8-jdk \
+  patchelf \
   pkg-config \
   python \
   sudo \


### PR DESCRIPTION
We had been relying on chrpath because patchelf was not available in older distros, but Leap Motion will likely only target Ubuntu 16.04 going forward.

readelf was missing from our images too, making any Docker-built Debian packages unusable since our migration to Docker.